### PR TITLE
Fix spaces in cookie name

### DIFF
--- a/frontend/src/pages/Main/Main.js
+++ b/frontend/src/pages/Main/Main.js
@@ -87,7 +87,7 @@ const SkillSlider = ({ value, setValue }) => {
 }
 
 const NotesBox = ({ bear }) => {
-  const [notes, setNotes] = useCookieState(`honey-heist-notes-${bear?.bear_name}-${bear?.gamecode}`, '')
+  const [notes, setNotes] = useCookieState(`honey-heist-notes-${bear?.bear_name.replace(/\s/g, '')}-${bear?.gamecode}`, '')
 
   return <NotesContainer>
     <NotesArea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "h0ney-he1st",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Notes fail to save if the bear has spaces in its name. This simple fix removes whitespaces so that the cookie will store correctly. (localstorage would be so much better for this though)